### PR TITLE
ENH: Add neck trimming step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+run_wt_old.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ RUN apt-get update && \
                     default-jdk \
                     git && \
     curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get install -y --no-install-recommends \
-                    nodejs && \
+    apt-get install -y --no-install-recommends && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install FSL
@@ -62,25 +61,27 @@ ENV PATH="${FSLDIR}/bin:$PATH"
 ENV FSLOUTPUTTYPE="NIFTI_GZ"
 
 # Install c3d
-ENV C3DPATH="/opt/convert3d-nightly" \
-    PATH="/opt/convert3d-nightly/bin:$PATH"
-RUN echo "Downloading Convert3D ..." \
-   && mkdir -p /opt/convert3d-nightly \
-   && curl -fsSL --retry 5 https://sourceforge.net/projects/c3d/files/c3d/Nightly/c3d-nightly-Linux-x86_64.tar.gz/download \
-   | tar -xz -C /opt/convert3d-nightly --strip-components 1
+#ENV C3DPATH="/opt/convert3d-nightly" \
+#    PATH="/opt//bin:$PATH"
+#RUN echo "Downloading Convert3D ..." \
+#   && mkdir -p /opt/convert3d-nightly \
+#   && curl -fsSL --retry 5 https://sourceforge.net/projects/c3d/files/c3d/Nightly/c3d-nightly-Linux-x86_64.tar.gz/download \
+#   | tar -xz -C /opt/convert3d-nightly --strip-components 1
 
+COPY --from=pyushkevich/itksnap:latest /usr/local/bin/c3d /opt/bin/c3d
+ENV PATH="/opt/bin:$PATH"
 
 # Install python packages
 RUN pip install --no-cache flywheel-sdk \
  && pip install --no-cache docker \
- && pip install --no-cache pathlib 
+ && pip install --no-cache pathlib
 
-#copy script and manifest into docker container 
+#copy script and manifest into docker container
 COPY manifest.json ${FLYWHEEL}/manifest.json
 COPY run.py ${FLYWHEEl}/run.py
 COPY . ${FLYWHEEL}/
 
-#COPY run.py ${FLYWHEEL}/run.py #Script goes here 
+#COPY run.py ${FLYWHEEL}/run.py #Script goes here
 RUN chmod +x ${FLYWHEEL}/*
 RUN chmod +x ${FLYWHEEL}/run.py
 #RUN chmod +x ${FLYWHEEL}/src/*
@@ -93,4 +94,3 @@ RUN chmod +x ${FLYWHEEL}/docker-env.sh
 #Workdirectory set
 WORKDIR /flywheel/v0
 ENTRYPOINT [ "python /flywheel/v0/run.py" ]
-

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,9 @@
         "FLYWHEEL": "/flywheel/v0",
         "FSLDIR": "/usr/share/fsl",
         "FSLMULTIFILEQUIT": "TRUE",
-        "FSLOUTPUTTYPE": "NIFTI_GZ"
+        "FSLOUTPUTTYPE": "NIFTI_GZ",
+        "PATH": "/opt/bin:/usr/share/fsl/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+"
     },
     "author": "Debarun De",
     "maintainer": "debarun.de20@gmail.com",
@@ -36,7 +38,7 @@
     "custom": {
         "gear-builder": {
             "category": "analysis",
-            "image": "debarunde/segmentationsysu2-1:0.0.1"
+            "image": "debarunde/segmentationsysu2-1:0.2.1"
         },
         "flywheel":{"suite": "BrainScienceCenter"}
     }

--- a/run.py
+++ b/run.py
@@ -5,11 +5,11 @@ import flywheel
 import shutil
 from pathlib import PosixPath
 
-
 # Get relevant container objects
 context = flywheel.GearContext()
 config = context.config
 analysis_id = context.destination['id']
+gear_output_dir = str(PosixPath(context.output_dir))
 
 fw = flywheel.Client(context.get_input('api_key')['key'])
 analysis_container = fw.get(analysis_id)
@@ -18,43 +18,65 @@ session_container = fw.get(analysis_container.parent['id'])
 subject_container = fw.get(session_container.parents['subject'])
 subject_label = subject_container.label
 
-output_file_FLAIR_name = 'subject' + '_sysu2_FLAIR_' + analysis_id + '.nii.gz'
-output_file_T1_name = 'subject' + '_sysu2_T1_' + analysis_id + '.nii.gz'
+#output_file_FLAIR_name = 'subject' + '_sysu2_FLAIR_' + analysis_id + '.nii.gz'
+# output_file_T1_name = 'subject' + '_sysu2_T1_' + analysis_id + '.nii.gz'
+outfile_root = 'sub-' + subject_label + '_' + analysis_id + '_sysu2'
+output_file_FLAIR_name = outfile_root+'_space-flair_desc-dseg.nii.gz'
+output_file_T1_name = outfile_root+'_space-T1w_desc-dseg.nii.gz'
 
 # Inputs and configs
-os.system('mkdir /input')
-os.system('mkdir /output')
-os.system('mkdir /input/pre')
-os.system('mkdir /input/mat')
+os.system('mkdir -p /output')
+os.system('mkdir -p /input/pre')
+os.system('mkdir -p /input/mat')
 
-flair_path = context.get_input_path('FLAIR')
-path = os.path.dirname(flair_path) # get the path minus the filename
-newname = os.path.join(path, 'FLAIR.nii.gz') # new name is path plus 'FLAIR_INPUT.nii.gz'
-os.rename(flair_path, newname) # do the rename
+flair_file = context.get_input_path('FLAIR')
+flair_path = os.path.dirname(flair_file) # get the path minus the filename
+new_flair_file = os.path.join(flair_path, 'FLAIR.nii.gz')
+if os.path.isfile(flair_file) and not os.path.isfile(new_t1_file): # Don't run if already renamed (i.e. in debugging)
+    os.rename(flair_file, new_flair_file)
 
-t1_path = context.get_input_path('T1')
-path = os.path.dirname(t1_path) # get the path minus the filename
-newname = os.path.join(path, 'T1.nii.gz') # new name is path plus 'T1.nii.gz'
-os.rename(t1_path, newname) # do the rename
+t1_file = context.get_input_path('T1')
+t1_path = os.path.dirname(t1_file) # get the path minus the filename
+new_t1_file = os.path.join(t1_path, 'T1_INPUT.nii.gz')
+if os.path.isfile(t1_file) and not os.path.isfile(new_t1_file):
+    os.rename(t1_file, new_t1_file)
 
-# Transform using FSL
-#os.system('/usr/share/fsl/bin/flirt -in /flywheel/v0/input/T1/T1_INPUT.nii.gz -ref /flywheel/v0/input/FLAIR/FLAIR.nii.gz -out /flywheel/v0/input/T1/T1.nii.gz -dof 6 -searchrx -180 180 -searchry -180 180 -searchrz -180 180 -omat /input/mat/T12FLAIR.mat') #possible straight directory for -out flag
+# RUN PROGRAM STEPS
+# 1) Trim T1
+# 2) Register T1 to FLAIR
+# 3) Run SYSU2 which will output the segmented mask
+# 4) Estimate FLAIR-T1 (just the inverse of the previous registration)
+# 5) Warp the segmentation in the FLAIR space to the T1 space. This will help in subsequent normalization step.
 
+# Trim T1
+trim_output = os.path.join(gear_output_dir, outfile_root+'_TrimNeckOutput.txt')
+cmd = "bash trim_neck.sh -d {0} {0} > {1} || echo 'Neck trimming exited with nonzero status';exit".format(new_t1_file, trim_output)
+print(cmd)
+os.system(cmd)
+shutil.copy(new_t1_file, os.path.join(gear_output_dir, outfile_root+'_desc-necktrim_T1w.nii.gz')) # copy results to output folder
+
+# Register T1 to FLAIR (Transform using FSL)
+t1_in_flair = os.path.join(t1_path, 'T1.nii.gz')
+os.system('/usr/share/fsl/bin/flirt -in {} -ref {} -out {} -dof 6 -searchrx -180 180 -searchry -180 180 -searchrz -180 180 -omat /input/mat/T12FLAIR.mat'.format(new_t1_file, new_flair_file, t1_in_flair)) #possible straight directory for -out flag
+shutil.copy(t1_in_flair, os.path.join(gear_output_dir, outfile_root+'_space-flair_desc-necktrim_T1w.nii.gz'))
+
+# Run SYSU2 which will output the segmented mask in FLAIR space
+# copy T1 and FLAIR to location where main algo can find e.g. /input/pre/T1.nii.gz
 for fname in os.listdir('/flywheel/v0/input'):
-      if os.path.isfile(os.path.join('/flywheel/v0/input/FLAIR', 'FLAIR.nii.gz')):
-          shutil.copy(os.path.join('/flywheel/v0/input/FLAIR', 'FLAIR.nii.gz'), os.path.join('/input/pre', 'FLAIR.nii.gz'))
-      if os.path.isfile(os.path.join('/flywheel/v0/input/T1', 'T1.nii.gz')):
-           shutil.copy(os.path.join('/flywheel/v0/input/T1', 'T1.nii.gz'), os.path.join('/input/pre', 'T1.nii.gz'))
+      if os.path.isfile(new_flair_file):
+          shutil.copy(new_flair_file, '/input/pre/FLAIR.nii.gz')
+      if os.path.isfile(t1_in_flair):
+           shutil.copy(t1_in_flair, '/input/pre/T1.nii.gz')
 
-# Commands
-os.system("python /wmhseg_example/example.py")
-os.system('/opt/convert3d-nightly/bin/c3d /input/pre/FLAIR.nii.gz /output/result.nii.gz -copy-transform -o /output/result.nii.gz')
-shutil.copy(os.path.join('/output', 'result.nii.gz'), os.path.join('/flywheel/v0/output', output_file_FLAIR_name))
+os.system("python /wmhseg_example/example.py") # RUN ALGORITHM
+os.system('/opt/bin/c3d /input/pre/FLAIR.nii.gz /output/result.nii.gz -copy-transform -o /output/result.nii.gz') # copy FLAIR transform to results
+shutil.copy('/output/result.nii.gz', os.path.join(gear_output_dir, output_file_FLAIR_name)) # copy result to outputfolder
 
+# Estimate FLAIR-T1 (just the inverse of the previous registration) (convert to FLAIR space and write)
+os.system('/usr/share/fsl/bin/convert_xfm -omat /input/mat/FLAIR2T1.mat -inverse /input/mat/T12FLAIR.mat')
 
+# Warp the segmentation in the FLAIR space to the T1 space. This will help in subsequent normalization step.
+os.system('/usr/share/fsl/bin/applywarp --ref={} --in=/output/result.nii.gz --out=/output/resultT1.nii.gz --premat=/input/mat/FLAIR2T1.mat --interp=nn'.format(new_t1_file))
 
-# convert to FLAIR space and write
-#os.system('/usr/share/fsl/bin/convert_xfm -omat /input/mat/FLAIR2T1.mat -inverse /input/mat/T12FLAIR.mat')
-#os.system('/usr/share/fsl/bin/applywarp --ref=/flywheel/v0/input/T1/T1_INPUT.nii.gz --in=/output/result.nii.gz --out=/output/resultT1.nii.gz --premat=/input/mat/FLAIR2T1.mat --interp=nn')
-#shutil.copy(os.path.join('/output','resultT1.nii.gz'), os.path.join('/flywheel/v0/output', output_file_T1_name))
-
+# copy segmentation in T1 space to output folder
+shutil.copy('/output/resultT1.nii.gz', os.path.join(gear_output_dir, output_file_T1_name))

--- a/trim_neck.sh
+++ b/trim_neck.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# ------------------------------------
+# Trim whitespace and lower resolution
+# ------------------------------------
+
+# Print usage by default
+if [[ $# -lt 1 || $1 == "-h" || $1 == "-help" || $1 == "--help" ]]; then
+  cat <<USAGETEXT
+  trim_neck: Brain MRI neck removal tool
+  usage:
+    trim_neck [options] input_image output_image
+  options:
+    -l <mm>        : Length (sup-inf) of the head that should be captured [180].
+    -c <mm>        : Clearance above head that should be captured [10].
+    -m <file>      : Location to save mask used for the computation.
+    -w <dir>       : Location to store intermediate files. Default: [$TMPDIR]
+    -d             : Verbose/debug mode
+USAGETEXT
+  exit 0
+fi
+
+# Default parameter values
+HEADLEN=180
+CLEARANCE=10
+unset WORKINGDIR MASKOUT DEBUG
+
+# Read the options
+while getopts "l:c:m:w:d" opt; do
+  case $opt in
+
+    l) HEADLEN=$OPTARG;;
+    c) CLEARANCE=$OPTARG;;
+    m) MASKOUT=$OPTARG;;
+    w) WORKINGDIR=$OPTARG;;
+    d) DEBUG=1;;
+    \?) echo "Unknown option $OPTARG"; exit 2;;
+    :) echo "Option $OPTARG requires an argument"; exit 2;;
+
+  esac
+done
+
+shift $((OPTIND-1))
+
+# Debugging
+if [[ $DEBUG ]]; then
+  set -x -e
+  VERBOSE="-verbose"
+fi
+
+# Read script parameters
+SOURCE=${1?}
+TARGET=${2?}
+
+# Create a temporary directory
+if [[ ! $WORKINGDIR ]]; then
+  if [[ ! $TMPDIR ]]; then
+    TMPDIR=$(mktemp -d)
+  fi
+  WORKINGDIR=$TMPDIR
+else
+  mkdir -p $WORKINGDIR
+fi
+
+# Create a landmark file for background / foreground segmentation
+cat > $WORKINGDIR/landmarks.txt << 'LANDMARKS'
+40x40x40% 1
+60x40x40% 1
+40x60x40% 1
+40x40x60% 1
+60x60x40% 1
+60x40x60% 1
+40x60x60% 1
+60x60x60% 1
+3x3x3% 2
+97x3x3% 2
+3x97x3% 2
+3x3x97% 2
+97x97x3% 2
+97x3x97% 2
+3x97x97% 2
+97x97x97% 2
+LANDMARKS
+
+# Intermediate images
+RAS_IMAGE=$WORKINGDIR/source_ras.nii.gz
+RAS_TRIMMED=$WORKINGDIR/trimmed_ras.nii.gz
+RAS_RESULT=$WORKINGDIR/result_ras.nii.gz
+RFMAP=$WORKINGDIR/rfmap.nii.gz
+LEVELSET=$WORKINGDIR/levelset.nii.gz
+MASK=$WORKINGDIR/mask.nii.gz
+SLAB=$WORKINGDIR/slab.nii.gz
+
+# Quick trim of the image
+c3d $VERBOSE \
+  $SOURCE -swapdim RAS -o $RAS_IMAGE \
+  -smooth-fast 1vox -resample-mm 2x2x2mm -o $WORKINGDIR/dsample_ras.nii.gz -as T1 \
+  -dup -steig 2.0 4x4x4 \
+  -push T1 -dup -scale 0 -lts $WORKINGDIR/landmarks.txt 15 -o $WORKINGDIR/samples.nii.gz \
+  -rf-param-patch 1x1x1 -rf-train $WORKINGDIR/myforest.rf -pop -rf-apply $WORKINGDIR/myforest.rf \
+  -o $RFMAP 
+
+# Quick level set of the image
+c3d $VERBOSE \
+  $RFMAP -as R -smooth-fast 1vox -resample 50% -stretch 0 1 -1 1 -dup \
+  $WORKINGDIR/samples.nii.gz -thresh 1 1 1 -1 -reslice-identity \
+  -levelset-curvature 5.0 -levelset 300 -o $LEVELSET \
+  -insert R 1 -reslice-identity -thresh 0 inf 1 0 -o $MASK
+
+# Get the dimensions of the image and the trim amount
+DIM=($(c3d $MASK -info-full | grep 'Dimen' | sed -e "s/.*\[//g" -e "s/,/ /g" -e "s/\].*//g"))
+DIMX=${DIM[0]}
+DIMY=${DIM[1]}
+DIMZ=${DIM[2]}
+
+# Amount to trim: 18cm = 90vox
+REGZ=$((HEADLEN / 2 + CLEARANCE / 2))
+TRIM=$((CLEARANCE / 2))
+
+# Translate the RAI code into a region specification
+REGCMD="0x0x0vox ${DIMX}x${DIMY}x${REGZ}vox"
+
+# while true ; do
+# :
+# done
+# Perform the trimming
+c3d $VERBOSE $MASK \
+  -dilate 1 ${DIMX}x${DIMY}x0vox -trim 0x0x${TRIM}vox \
+  -region $REGCMD -thresh -inf inf 1 0 -o $SLAB -popas S \
+  $SOURCE -as I -int 0 -push S -reslice-identity -trim 0vox -as SS -o $WORKINGDIR/slab_src.nii.gz \
+  -push I -reslice-identity -o $TARGET  
+
+# If mask requested, reslice mask to target space
+if [[ $MASKOUT ]]; then
+  c3d $SOURCE $LEVELSET -reslice-identity -thresh 0 inf 1 0 -o $MASKOUT/mask.nii.gz
+fi


### PR DESCRIPTION
I inserted a call to trim_neck.sh in the main run script as the first preprocessing step. I also changed some of the variable names and related file paths to make things easier to read and less dependent on explicit file paths where possible. Finally, I changed the c3d install method (copied from ftdc-picsl/antsct-aging), because I was having trouble with the original regarding versioning (that version did not have -swapdim which cause the trim_neck.sh script to break). The new method is less dependent on the nightly version (is based on a standalone Docker container ensuring max version preservation).

Best,
Will